### PR TITLE
Potential fix for code scanning alert no. 1: Bad HTML filtering regexp

### DIFF
--- a/client/src/htsxEngine.ts
+++ b/client/src/htsxEngine.ts
@@ -23,12 +23,21 @@ export interface QuantumState {
   pulse: number;
 }
 
+import { parseDocument } from "htmlparser2";
+
 export const htsxRender = (htsxContent: string, props: any) => {
-  // Extract HTSX script and template sections
-  const scriptMatch = htsxContent.match(/<script[^>]*>([\s\S]*?)<\/script>/);
-  const script = scriptMatch ? scriptMatch[1] : "";
-  const templateMatch = htsxContent.match(/<template>([\s\S]*?)<\/template>/);
-  let template = templateMatch ? templateMatch[1] : "";
+  // Parse HTSX content to extract <script> and <template> sections
+  const document = parseDocument(htsxContent);
+  let script = "";
+  let template = "";
+
+  document.childNodes.forEach((node) => {
+    if (node.type === "tag" && node.name.toLowerCase() === "script") {
+      script = node.children.map((child) => child.data).join("");
+    } else if (node.type === "tag" && node.name.toLowerCase() === "template") {
+      template = node.children.map((child) => child.data).join("");
+    }
+  });
 
   // Compile SpiralLang/TypeScript code
   const compiled = transform(script, {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "htmlparser2": "^10.0.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/SSDF_Private_-_Public_Gates/security/code-scanning/1](https://github.com/CreoDAMO/SSDF_Private_-_Public_Gates/security/code-scanning/1)

To fix the issue, we should replace the custom regex with a robust and well-tested HTML parser library, such as `htmlparser2`, to extract the `<script>` content. This approach ensures that all valid `<script>` tags, regardless of case or syntax variations, are correctly handled. Using a library also avoids the pitfalls of custom regex-based solutions.

The changes will involve:
1. Installing the `htmlparser2` library.
2. Replacing the regex-based extraction of `<script>` and `<template>` content with parsing logic using `htmlparser2`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
