### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "express-rate-limit": "^7.5.1"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,6 +1,7 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
+import rateLimit from "express-rate-limit";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
@@ -78,8 +79,14 @@ export function serveStatic(app: Express) {
 
   app.use(express.static(distPath));
 
+  // set up rate limiter: maximum of 100 requests per 15 minutes
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  app.use("*", limiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/SSDF_Private_-_Public_Gates/security/code-scanning/3](https://github.com/CreoDAMO/SSDF_Private_-_Public_Gates/security/code-scanning/3)

To address the issue, we should apply rate limiting to the route that performs the file system access. This can be achieved using the `express-rate-limit` package, which is a well-known middleware for limiting the number of requests per client/IP within a specified timeframe.

1. Install the `express-rate-limit` package to enable rate limiting.
2. Configure a rate limiter middleware with appropriate limits (e.g., maximum 100 requests per 15 minutes).
3. Apply the rate limiter to the specific route handler on line 82 that serves the `index.html` file from the file system.

This approach ensures the application is protected from excessive requests while maintaining its existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
